### PR TITLE
Fix PostgreSQL platform check

### DIFF
--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -72,7 +72,7 @@ class FileRepository
         if ($platform instanceof DoctrineMySQLPlatform) {
             return 'mysql';
         }
-        if ($platform instanceof DoctrinePostgreSqlPlatform) {
+        if ($platform instanceof DoctrinePostgreSQLPlatform) {
             return 'postgresql';
         }
         if ($platform instanceof DoctrineSQLitePlatform) {


### PR DESCRIPTION
## Summary
- fix Doctrine DBAL class name for PostgreSQL platform

## Testing
- `./Build/bin/phpunit -c Build/phpunit/UnitTests.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841aae438388329910c16662ebc7587