### PR TITLE
Fix TextMedia capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ class SoundcloudOutputEventListener
 In the backend, the preview is used by TextMediaRenderer. For online media, this
 only displays the provider's icon, in this case soundcloud. If you want to display
 the thumbnail, for example, you need your own renderer that overwrites
-Textmedia. An example renderer is available in the project. Caution: This
+TextMedia. An example renderer is available in the project. Caution: This
 overwrites all text media elements, so only use this renderer as a basis.
 
 You register a renderer in the TCA `Configuration/TCA/Overrides/tt_content.php`


### PR DESCRIPTION
## Summary
- fix capitalization of `TextMedia` in README backend preview section

## Testing
- `composer ci:php:lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad7bef7083298728faea957ad0e2