### PR TITLE
Add unit tests for DB platform detection

### DIFF
--- a/Tests/Unit/Domain/Repository/FileRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/FileRepositoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ayacoo\AyacooSoundcloud\Tests\Unit\Domain\Repository;
+
+use Ayacoo\AyacooSoundcloud\Domain\Repository\FileRepository;
+use Doctrine\DBAL\Platforms\AbstractPlatform as DoctrineAbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class FileRepositoryTest extends UnitTestCase
+{
+    private FileRepository $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new FileRepository();
+    }
+
+    #[Test]
+    #[DataProvider('platformIdentifierDataProvider')]
+    public function getPlatformIdentifierReturnsExpectedIdentifier(DoctrineAbstractPlatform $platform, string $expected): void
+    {
+        $params = [$platform];
+        $methodName = 'getPlatformIdentifier';
+        $result = $this->buildReflectionForProtectedFunction($methodName, $params);
+
+        self::assertSame($expected, $result);
+    }
+
+    public static function platformIdentifierDataProvider(): array
+    {
+        return [
+            'MariaDB platform' => [new MariaDBPlatform(), 'mysql'],
+            'MySQL platform' => [new MySQLPlatform(), 'mysql'],
+            'PostgreSQL platform' => [new PostgreSQLPlatform(), 'postgresql'],
+            'SQLite platform' => [new SQLitePlatform(), 'sqlite'],
+        ];
+    }
+
+    #[Test]
+    public function getPlatformIdentifierWithUnsupportedPlatformThrowsRuntimeException(): void
+    {
+        $platformMock = self::createMock(DoctrineAbstractPlatform::class);
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->buildReflectionForProtectedFunction('getPlatformIdentifier', [$platformMock]);
+    }
+
+    private function buildReflectionForProtectedFunction(string $methodName, array $params)
+    {
+        $reflection = new \ReflectionClass($this->subject);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($this->subject, $params);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `FileRepository::getPlatformIdentifier`

## Testing
- `./.Build/bin/phpunit -c Build/phpunit/UnitTests.xml Tests/Unit/Domain/Repository/FileRepositoryTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad8179e4832999e5dfb64c140863